### PR TITLE
Glossary and sql inserts

### DIFF
--- a/orchex/dataextract.py
+++ b/orchex/dataextract.py
@@ -610,6 +610,14 @@ class DataSource:
         markdown_report.add_heading("Glossary", 4)
 
         if self.glossary:
+            assert set(self.df.columns) == set(
+                self.glossary.keys()
+            ), "The columns in the dataframe are different to the glossary."
+
+            assert list(self.df.columns) == list(
+                self.glossary.keys()
+            ), "The columns in the dataframe are in a different order to the glossary."
+
             formatted_glossary = {
                 k: v.replace("\n\n", "<br><br>") for k, v in self.glossary.items()
             }


### PR DESCRIPTION
`orchex/dataextract.py`
Added 2 asserts for the glossaries 
- Checks glossary items = df columns.
- Checks they are in the same order. 
- Two separate asserts to better diagnose the issue.

`orchex/helper_functions.py`
- Big rework of `create_join_identifiers_table`
- Now creates insert statements with batches of 1000
- Will improve performance and is 'backwards compatible' so no code changes needed.
- Tested with ~5 orchex-scripts extracts/transforms. 