### PR TITLE
Ignore common metrics for list variables

### DIFF
--- a/orchex/dataextract.py
+++ b/orchex/dataextract.py
@@ -8,6 +8,7 @@ import random
 import re
 import string
 import zipfile
+import typing
 from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -498,7 +499,7 @@ class DataSource:
             return {
                 "field": field.name,
                 "count": field.count(),
-                "nunique": field.nunique(),
+                "nunique": field.nunique() if isinstance(field, typing.Hashable) else -1,
                 "non-null": field.notnull().sum(),
             }
 
@@ -562,7 +563,7 @@ class DataSource:
                 }
             )
 
-            if stats["nunique"] < 10:
+            if stats["nunique"] < 10 and stats["nunique"] >= 0:
                 stats["value_counts"] = str(field.value_counts().to_dict())
 
             return stats


### PR DESCRIPTION
Updates to Orchex Scripts introduced lists nested within dataframes. Because these are mutable, they are unhashable which causes issues with some of the current stats. This current workaround ignores these columns for common stats, but this doesn't necessarily need to be the case.

Other options:
1. Output stats about the nested lists. Could get complex given the type of list.
2. Store lists as a string. Current common stats become meaningless (i.e., most elements will be unique)