### PR TITLE
save + export all the time

### DIFF
--- a/orchex/dataextract.py
+++ b/orchex/dataextract.py
@@ -811,6 +811,9 @@ class DataExtract:
         if data_source_names is None:
             data_source_names = self.data_sources.keys()
 
+        # Save this extract to preserve psuedonization dictionary before sharing
+        self.save()
+
         for name in data_source_names:
             ds = self.data_sources[name]
             ds.export()


### PR DESCRIPTION
Adding save() to the export function to always preserve the entire export class before exporting the public folder. This ensures that any changes to the pseudonymization dictionary are up-to-date with the exported datasources.