### PR TITLE
Save an immutable version of the original dataframe

### DIFF
--- a/orchex/dataextract.py
+++ b/orchex/dataextract.py
@@ -310,6 +310,7 @@ class DataSource:
         """
         self.name = name
         self.description = description
+        self.immutable_original_df = tuple(dataframe.itertuples(index=False))
         self.df = dataframe
         self.columns_to_entities = columns_to_entities
         self.whitelist = whitelist


### PR DESCRIPTION
The current implementation of pseudonymization functions act in-place and overrides the original data frame. This can make it challenging to re-run an extract using the same source with updated downstream logic. Here we save an immutable version of the dataframe that will be contained in the private pkl.